### PR TITLE
Fix navbar home link to point to root

### DIFF
--- a/DotNetAppSqlDb/Views/Shared/_Layout.cshtml
+++ b/DotNetAppSqlDb/Views/Shared/_Layout.cshtml
@@ -16,7 +16,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                @Html.ActionLink("My TodoList App", "Index", "Home", new { area = "" }, new { @class = "navbar-brand" })
+                @Html.ActionLink("My TodoList App", "Index", new { controller = "Todos" }, new { @class = "navbar-brand" })
             </div>
         </div>
     </div>


### PR DESCRIPTION
The "My TodoList App" navbar link pointed to `/Home` that didn't exist. This fix points it back to the index page by making it just load the default controller `Index` function.